### PR TITLE
docs: add documentation for building and deploying the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+build
 
 # Test binary, built with `go test -c`
 *.test
@@ -28,3 +29,4 @@ tmp
 
 # task file temporary files
 .task
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ task container container_name=my-app container_tag=test
 Deploying to Railway doesn't require any special configuration. You can just fork this repository and configure Railway to use
 your forked repository. Railway will then automatically build and deploy your main branch on every change. You can click the
 `Deploy to Railway` badge at the top of the README to streamline this process.
+
+**Note**: This template was designed to deploy to Railway in mind but there is nothing prohibiting this template from working
+elsewhere. The binary is just a standard go http server. The Dockerfile should work just about anywhere the runs containers.
 ### Development Mode
 
 Development mode will watch for changes in the source code and restart the server automatically.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,39 @@
 
 ### Prerequisites
 Install [Taskfile](https://taskfile.dev/) and [Air](https://github.com/cosmtrek/air#installation)
+
 run `npm install`
 
+### Generating Code
+The server binary embeds the static file directory and serves anything contained within under `/static`. To build the server
+binary you should first generate the `tailwind`, `templ`, and any other necessary generated code for your app:
+
+```
+task generate
+```
+
+### Building the binary:
+Once all files have been generated, the binary can be built just like any other go binary:
+```
+go build -o build/server main.go
+```
+Or you can use the `build` task which will generate code before building the binary:
+```
+task build
+```
+### Containerized Builds
+
+You can easily containerize the build using the provided [Dockerfile](Dockerfile). Make sure all code is generated before triggering
+a build of the container, or use the `container` task which will generate any code first:
+
+```
+task container container_name=my-app container_tag=test
+```
+#### Railway
+
+Deploying to Railway doesn't require any special configuration. You can just fork this repository and configure Railway to use
+your forked repository. Railway will then automatically build and deploy your main branch on every change. You can click the
+`Deploy to Railway` badge at the top of the README to streamline this process.
 ### Development Mode
 
 Development mode will watch for changes in the source code and restart the server automatically.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,11 +7,27 @@ dotenv:
 env:
   PORT: 8080
 
+vars:
+  container_name: app
+  container_tag: latest
+
 tasks:
   dev:
     run: always
     cmds:
       - air
+
+  build:
+    deps:
+      - task: generate
+    cmds:
+      - CGO_ENABLED=0 go build -o build/server main.go
+
+  container:
+    deps:
+      - task: generate
+    cmds:
+      - docker build -t {{.container_name}}:{{.container_tag}} .
 
   generate:
     aliases:


### PR DESCRIPTION
Improves the Taskfile and README to add more details on building the binary and deploying the app to railway.

closes #4 